### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/analogj/scrutiny:v0.8.3-omnibus
 ENV SCRUTINY_WEB_LISTEN_PORT=8000 \
     COLLECTOR_API_ENDPOINT=http://127.0.0.1:8000
 
-RUN sed -i 's/localhost:8080/127.0.0.1:8000/' /etc/services.d/collector-once/run
+RUN ls -l /etc/services.d/ && sed -i 's/localhost:8080/127.0.0.1:8000/' /etc/services.d/collector-once/run
 
 COPY --chmod=775 start.sh /start.sh
 COPY --chmod=775 notify.sh /notify.sh


### PR DESCRIPTION
- Follow-up to https://github.com/szaimen/aio-scrutiny/pull/17
- Try to fix https://github.com/szaimen/aio-scrutiny/actions/runs/21827007028/job/62974484435

```
> [linux/amd64 2/5] RUN sed -i 's/localhost:8080/127.0.0.1:8000/' /etc/services.d/collector-once/run:
0.063 sed: can't read /etc/services.d/collector-once/run: No such file or directory
------
Dockerfile:6
--------------------
   4 |         COLLECTOR_API_ENDPOINT=http://127.0.0.1:8000/
   5 |     
   6 | >>> RUN sed -i 's/localhost:8080/127.0.0.1:8000/' /etc/services.d/collector-once/run
   7 |     
   8 |     COPY --chmod=775 start.sh /start.sh
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c sed -i 's/localhost:8080/127.0.0.1:8000/' /etc/services.d/collector-once/run" did not complete successfully: exit code: 2
```